### PR TITLE
feat(Editor): add save scene before runtime

### DIFF
--- a/BEngineEditor/Code/UI/Screens/SceneScreen.cs
+++ b/BEngineEditor/Code/UI/Screens/SceneScreen.cs
@@ -30,6 +30,10 @@ namespace BEngineEditor
 			ImGui.SetCursorPosX(ImGui.GetWindowWidth() / 2 - runtimeStateButtonWidth / 2 - spacing);
 			if (ImGui.Button(_projectContext.CurrentProject.Runtime ? "Stop" : "Start", new Vector2(runtimeStateButtonWidth, 25)))
 			{
+				if(!_projectContext.CurrentProject.Runtime)
+				{
+					_projectContext.CurrentProject.SaveCurrentScene();
+				}
 				_projectContext.CurrentProject.SwipeRuntime();
 			}
 


### PR DESCRIPTION
close #62 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced the scene management system to automatically save the current scene before switching runtime states, ensuring no progress is lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->